### PR TITLE
Add support for headings without spaces.

### DIFF
--- a/creole.js
+++ b/creole.js
@@ -133,12 +133,12 @@ Parse.Simple.Base.Rule.prototype = {
                     if (best.index == 0) { break; }
                 }
             }
-                
+
             var pos = best ? best.index : tail.length;
             if (pos > 0) {
                 this.fallback.apply(node, tail.substring(0, pos), options);
             }
-            
+
             if (!best) { break; }
 
             if (!rule.build) { rule = new this.constructor(rule); }
@@ -169,7 +169,7 @@ Parse.Simple.Base.Rule.prototype = {
             }
             node.appendChild(document.createTextNode(data));
         }
-    }    
+    }
 };
 
 Parse.Simple.Base.Rule.prototype.constructor = Parse.Simple.Base.Rule;
@@ -184,7 +184,7 @@ Parse.Simple.Creole = function(options) {
     rx.interwikiPrefix = '[\\w.]+:';
     rx.interwikiLink = rx.interwikiPrefix + rx.link;
     rx.img = '\\{\\{((?!\\{)[^|}\\n]*(?:}(?!})[^|}\\n]*)*)' +
-             (options && options.strict ? '' : '(?:') + 
+             (options && options.strict ? '' : '(?:') +
              '\\|([^}~\\n]*((}(?!})|~.)[^}~\\n]*)*)' +
              (options && options.strict ? '' : ')?') +
              '}}';
@@ -203,7 +203,7 @@ Parse.Simple.Creole = function(options) {
         hr: { tag: 'hr', regex: /(^|\n)\s*----\s*(\n|$)/ },
 
         br: { tag: 'br', regex: /\\\\/ },
-        
+
         preBlock: { tag: 'pre', capture: 2,
             regex: /(^|\n)\{\{\{\n((.*\n)*?)\}\}\}(\n|$)/,
             replaceRegex: /^ ([ \t]*\}\}\})/gm,
@@ -268,12 +268,12 @@ Parse.Simple.Creole = function(options) {
         namedLink: { regex: '\\[\\[(' + rx.link + ')\\|(' + rx.linkText + ')\\]\\]',
             build: function(node, r, options) {
                 var link = document.createElement('a');
-                
+
                 link.href = options && options.linkFormat
                     ? formatLink(r[1].replace(/~(.)/g, '$1'), options.linkFormat)
                     : r[1].replace(/~(.)/g, '$1');
                 this.apply(link, r[2], options);
-                
+
                 node.appendChild(link);
             } },
 
@@ -303,13 +303,13 @@ Parse.Simple.Creole = function(options) {
     g.namedInterwikiLink = { regex: '\\[\\[(' + rx.interwikiLink + ')\\|(' + rx.linkText + ')\\]\\]',
         build: function(node, r, options) {
                 var link = document.createElement('a');
-                
+
                 var m, f;
                 if (options && options.interwiki) {
                 m = r[1].match(/(.*?):(.*)/);
                 f = options.interwiki[m[1]];
             }
-            
+
             if (typeof f == 'undefined') {
                 if (!g.namedLink.apply) {
                     g.namedLink = new this.constructor(g.namedLink);
@@ -318,9 +318,9 @@ Parse.Simple.Creole = function(options) {
             }
 
             link.href = formatLink(m[2].replace(/~(.)/g, '$1'), f);
-            
+
             this.apply(link, r[2], options);
-            
+
             node.appendChild(link);
         }
     };
@@ -334,7 +334,7 @@ Parse.Simple.Creole = function(options) {
 
     for (var i = 1; i <= 6; i++) {
         g['h' + i] = { tag: 'h' + i, capture: 2,
-            regex: '(^|\\n)[ \\t]*={' + i + '}[ \\t]' +
+            regex: '(^|\\n)[ \\t]*={' + i + '}(?:[ \\t]*(?![=]))' +
                    '([^~]*?(~(.|(?=\\n)|$))*)[ \\t]*=*\\s*(\\n|$)'
         };
     }

--- a/lib/Parse/Simple/Base.js
+++ b/lib/Parse/Simple/Base.js
@@ -108,12 +108,12 @@ Parse.Simple.Base.Rule.prototype = {
                     if (best.index == 0) { break; }
                 }
             }
-                
+
             var pos = best ? best.index : tail.length;
             if (pos > 0) {
                 this.fallback.apply(node, tail.substring(0, pos), options);
             }
-            
+
             if (!best) { break; }
 
             if (!rule.build) { rule = new this.constructor(rule); }
@@ -144,7 +144,7 @@ Parse.Simple.Base.Rule.prototype = {
             }
             node.appendChild(document.createTextNode(data));
         }
-    }    
+    }
 };
 
 Parse.Simple.Base.Rule.prototype.constructor = Parse.Simple.Base.Rule;

--- a/lib/Parse/Simple/Creole.js
+++ b/lib/Parse/Simple/Creole.js
@@ -23,7 +23,7 @@ Parse.Simple.Creole = function(options) {
     rx.interwikiPrefix = '[\\w.]+:';
     rx.interwikiLink = rx.interwikiPrefix + rx.link;
     rx.img = '\\{\\{((?!\\{)[^|}\\n]*(?:}(?!})[^|}\\n]*)*)' +
-             (options && options.strict ? '' : '(?:') + 
+             (options && options.strict ? '' : '(?:') +
              '\\|([^}~\\n]*((}(?!})|~.)[^}~\\n]*)*)' +
              (options && options.strict ? '' : ')?') +
              '}}';
@@ -42,7 +42,7 @@ Parse.Simple.Creole = function(options) {
         hr: { tag: 'hr', regex: /(^|\n)\s*----\s*(\n|$)/ },
 
         br: { tag: 'br', regex: /\\\\/ },
-        
+
         preBlock: { tag: 'pre', capture: 2,
             regex: /(^|\n)\{\{\{\n((.*\n)*?)\}\}\}(\n|$)/,
             replaceRegex: /^ ([ \t]*\}\}\})/gm,
@@ -107,12 +107,12 @@ Parse.Simple.Creole = function(options) {
         namedLink: { regex: '\\[\\[(' + rx.link + ')\\|(' + rx.linkText + ')\\]\\]',
             build: function(node, r, options) {
                 var link = document.createElement('a');
-                
+
                 link.href = options && options.linkFormat
                     ? formatLink(r[1].replace(/~(.)/g, '$1'), options.linkFormat)
                     : r[1].replace(/~(.)/g, '$1');
                 this.apply(link, r[2], options);
-                
+
                 node.appendChild(link);
             } },
 
@@ -142,13 +142,13 @@ Parse.Simple.Creole = function(options) {
     g.namedInterwikiLink = { regex: '\\[\\[(' + rx.interwikiLink + ')\\|(' + rx.linkText + ')\\]\\]',
         build: function(node, r, options) {
                 var link = document.createElement('a');
-                
+
                 var m, f;
                 if (options && options.interwiki) {
                 m = r[1].match(/(.*?):(.*)/);
                 f = options.interwiki[m[1]];
             }
-            
+
             if (typeof f == 'undefined') {
                 if (!g.namedLink.apply) {
                     g.namedLink = new this.constructor(g.namedLink);
@@ -157,9 +157,9 @@ Parse.Simple.Creole = function(options) {
             }
 
             link.href = formatLink(m[2].replace(/~(.)/g, '$1'), f);
-            
+
             this.apply(link, r[2], options);
-            
+
             node.appendChild(link);
         }
     };
@@ -173,7 +173,7 @@ Parse.Simple.Creole = function(options) {
 
     for (var i = 1; i <= 6; i++) {
         g['h' + i] = { tag: 'h' + i, capture: 2,
-            regex: '(^|\\n)[ \\t]*={' + i + '}[ \\t]' +
+            regex: '(^|\\n)[ \\t]*={' + i + '}(?:[ \\t]*(?![=]))' +
                    '([^~]*?(~(.|(?=\\n)|$))*)[ \\t]*=*\\s*(\\n|$)'
         };
     }

--- a/tests/creole.html
+++ b/tests/creole.html
@@ -144,6 +144,36 @@ var tests = [
     input:  "====== Header =",
     output: "<h6>Header</h6>"
   },
+  { // Test h1 (no spaces)
+    name:   "h1 (no spaces)",
+    input:  "=Header=",
+    output: "<h1>Header</h1>"
+  },
+  { // Test h2 (no spaces)
+    name:   "h2 (no spaces)",
+    input:  "==Header=",
+    output: "<h2>Header</h2>"
+  },
+  { // Test h3 (no spaces)
+    name:   "h3 (no spaces)",
+    input:  "===Header=",
+    output: "<h3>Header</h3>"
+  },
+  { // Test h4 (no spaces)
+    name:   "h4 (no spaces)",
+    input:  "====Header=",
+    output: "<h4>Header</h4>"
+  },
+  { // Test h5 (no spaces)
+    name:   "h5 (no spaces)",
+    input:  "=====Header",
+    output: "<h5>Header</h5>"
+  },
+  { // Test h6 (no spaces)
+    name:   "h6 (no spaces)",
+    input:  "======Header=",
+    output: "<h6>Header</h6>"
+  },
   { // Test above h6 (should be ignored)
     name:   ">h6",
     input:  "======= Header =",


### PR DESCRIPTION
People write very often headings without spaces, like this:
==Environment==

This patch adds support for that syntax too.
