### PR TITLE
Inline markup

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,27 @@
+{
+  "name": "jscreole",
+  "version": "1.0.0",
+  "homepage": "https://github.com/codeholic/jscreole",
+  "authors": [
+    "Ivan Fomichev"
+  ],
+  "description": "A JavaScript library for parsing Creole 1.0 wiki markup.",
+  "main": "lib/creole.js",
+  "moduleType": [
+    "globals",
+    "node"
+  ],
+  "keywords": [
+    "creole",
+    "markup",
+    "parser"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}

--- a/lib/creole.js
+++ b/lib/creole.js
@@ -63,6 +63,7 @@ var creole = function(options) {
         _paragraph: { _tag: 'p', _capture: 0,
             _regex: /(^|\n)([ \t]*\S.*(\n|$))+/ },
         _text: { _capture: 0, _regex: /(^|\n)([ \t]*[^\s].*(\n|$))+/ },
+        _inlineRoot : { _capture: 0, _regex: /(^|\n)([ \t]*[^\s].*(\n|$))+/ },
 
         _strong: { _tag: 'strong', _capture: 1,
             _regex: /\*\*([^*~]*((\*(?!\*)|~(.|(?=\n)|$))[^*~]*)*)(\*\*|\n|$)/ },
@@ -177,6 +178,7 @@ var creole = function(options) {
             g.h4._children = g.h5._children = g.h6._children =
             g._singleLine._children = g._paragraph._children =
             g._text._children = g._strong._children = g._em._children =
+            g._inlineRoot._children =
         [ g._escapedSequence, g._strong, g._em, g._br, g._rawUri,
             g._namedUri, g._namedInterwikiLink, g._namedLink,
             g._unnamedUri, g._unnamedInterwikiLink, g._unnamedLink,
@@ -196,6 +198,7 @@ creole._base = function(grammar, options) {
 
     this._grammar = grammar;
     this._grammar._root = new this._ruleConstructor(this._grammar._root);
+    this._grammar._inlineRoot = new this._ruleConstructor(this._grammar._inlineRoot);
     this._options = options;
 };
 
@@ -221,7 +224,12 @@ creole._base.prototype = {
             options = this._options;
         }
         data = data.replace(/\r\n?/g, '\n');
-        this._grammar._root._apply(node, data, options);
+        if (options && options.inline) {
+          data = data.replace(/\n+/g, ' ')
+          this._grammar._inlineRoot._apply(node, data, options);
+        } else {
+          this._grammar._root._apply(node, data, options);
+        }
         if (options && options.forIE) { node.innerHTML = node.innerHTML.replace(/\r?\n/g, '\r\n'); }
     }
 };

--- a/lib/creole.js
+++ b/lib/creole.js
@@ -332,3 +332,7 @@ creole._rule.prototype.constructor = creole._rule;
 creole.prototype = new creole._base();
 
 creole.prototype.constructor = creole;
+
+if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
+  module.exports = creole;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "jscreole",
+  "version": "1.0.0",
+  "main": "lib/creole.js"
+}

--- a/tests/creole.html
+++ b/tests/creole.html
@@ -631,6 +631,20 @@ var tests = [
     input:  "{{image.png}}",
     output: '<p><img alt="Image" src="image.png"/></p>',
     options: { defaultImageText: 'Image' }
+  },
+
+  // test inline-only mode
+  {
+    name:   "Inline markup",
+    input:  "This is //some// **markup**",
+    output: 'This is <em>some</em> <strong>markup</strong>',
+    options: { inline: true }
+  },
+  {
+    name:   "Inline markup with newlines",
+    input:  "This is //some//\n\n**markup**",
+    output: 'This is <em>some</em> <strong>markup</strong>',
+    options: { inline: true }
   }
 ];
 


### PR DESCRIPTION
Add support for converting inline markup only via passing `inline: true` option.

This PR depends on #8 to be merged first.